### PR TITLE
Execute Ruby code inside config files

### DIFF
--- a/lib/consul_application_settings/file_provider.rb
+++ b/lib/consul_application_settings/file_provider.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'erb'
 
 module ConsulApplicationSettings
   # Provides access to settings stored in file system with support of base and local files
@@ -33,7 +34,7 @@ module ConsulApplicationSettings
     def read_yml(path)
       return {} unless File.exist?(path)
 
-      YAML.safe_load(IO.read(path))
+      YAML.safe_load(ERB.new(File.read(path)).result)
     rescue Psych::SyntaxError, Errno::ENOENT => e
       raise ConsulApplicationSettings::Error, "Cannot read settings file at #{path}: #{e.message}"
     end

--- a/spec/consul_application_settings/file_provider_spec.rb
+++ b/spec/consul_application_settings/file_provider_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe ConsulApplicationSettings::FileProvider do
       end
     end
 
+    context 'when the key is an executable ruby code' do
+      it 'executes it and returns the value' do
+        expect(provider.get(:erb_key)).to eq 4
+      end
+    end
+
     it 'returns list values' do
       expect(provider.get(:collection)).to eq(%w[a b c])
     end

--- a/spec/support/fixtures/base_application_settings.yml
+++ b/spec/support/fixtures/base_application_settings.yml
@@ -11,3 +11,4 @@ collection:
 instances: 4
 tracking_coefficient: 0.5
 secret: 'super secret'
+erb_key: <%= 2 * 2 %>


### PR DESCRIPTION
It is pretty helpful to have values in config files dependent on instance
variables. Having so, we can store all config in the environment, which
is a nice 12-factor app practice. Therefore, the configuration files
become a kind of anticoruption layer with a tiny logic of setting
default values when the env variable isn't set.

This commit unlocks such functionality.